### PR TITLE
Round dimensions to nearest whole number

### DIFF
--- a/thumbs/video-thumb.js
+++ b/thumbs/video-thumb.js
@@ -56,11 +56,11 @@ class VideoThumbnailSupplier extends ThumbnailSupplier {
         if(videoDimension.width > videoDimension.height) {
             return {
                 width: this.size.width,
-                height: this.size.width * videoDimension.height / videoDimension.width
+                height: Math.round(this.size.width * videoDimension.height / videoDimension.width)
             }
         } else {
             return {
-                width: this.size.height * videoDimension.width / videoDimension.height,
+                width: Math.round(this.size.height * videoDimension.width / videoDimension.height),
                 height: this.size.height
             }
         }


### PR DESCRIPTION
Addresses #4: After I added some logging, I discovered the reason that I was getting square thumbnails:
```
Attempting to generate thumbnail for: ./data/sample-video-1280.mp4
Successfully generated thumbnail: /home/kevin/.cache/thumbsupply/480p/fcb64633aae17c80ee1383aadf438aa072365e354ea0ebbc5bc65cbb00f3ebc1.png
Attempting to generate thumbnail for: ./data/sample-video-852.mp4
Error: Invalid size parameter: 480x270.4225352112676
    at FfmpegCommand.proto.takeScreenshots.proto.thumbnail.proto.thumbnails.proto.screenshot.proto.screenshots (/home/kevin/Desktop/thumbsupply/node_modules/fluent-ffmpeg/lib/recipes.js:150:15)
    at getVideoDimension.then.then.res (/home/kevin/Desktop/thumbsupply/thumbs/video-thumb.js:22:26)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
Successfully generated thumbnail: /home/kevin/.cache/thumbsupply/480p/ef523a3c240b2d033869d0890c8ef6f21953729248d5edd067a2902fad50b43e.png
```

`getOptimalThumbnailResolution` was returning non-integer values for the resolution which caused ffmpeg to error out. This caused the code to reach the catch block of `createThumbnail` which generates a thumbnail using the thumbnail size (which defaults to 480x480) as a failsafe.

This PR addresses the issue by rounding the results of `getOptimalThumbnailResolution` to the nearest integer. For values which were already integers, this will have no effect, but for all other values this will ensure the aspect ratio is kept similar to the source material.